### PR TITLE
Support OR conditions in findWhere()

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -94,7 +94,12 @@ class Model
         $s = new static();
         $where = [];
         foreach ($conditions as $key => $value) {
-            if (is_string($value)) {
+            if (is_array($value)) { // support aggregating conditions with another boolean operator
+                $subcaluse = [];
+                foreach ($value as $subkey => $subvalue)
+                    $subclause[] = $key.' = '.(is_string($subvalue) ? '"'.addslashes($subvalue).'"' : $subvalue);
+                $where[] = '(' . join(" $key ", $subclause) . ')';
+            } elseif (is_string($value)) {
                 $where[] = $key.' ="'.addslashes($value).'"';
             } else {
                 $where[] = $key.' = '.$value;

--- a/src/Model.php
+++ b/src/Model.php
@@ -108,6 +108,9 @@ class Model
                 $where[] = $key.' = '.$value;
             }
         }
+        if (!is_string($logicalOp)) // caller sent us an indexed array.
+            // they probably only have 1 condition, but better safe than sorry
+            $logicalOp = '&&';
         return join(" $logicOp ", $where);
     }
 

--- a/src/Model.php
+++ b/src/Model.php
@@ -108,9 +108,9 @@ class Model
                 $where[] = $key.' = '.$value;
             }
         }
-        if (!is_string($logicalOp)) // caller sent us an indexed array.
+        if (!is_string($logicOp)) // caller sent us an indexed array.
             // they probably only have 1 condition, but better safe than sorry
-            $logicalOp = '&&';
+            $logicOp = '&&';
         return join(" $logicOp ", $where);
     }
 


### PR DESCRIPTION
Add support for more than straightforward OR conditions by allowing the user to provide subclauses with their own logical operators that are parsed recursively.

For example:

```
Model::findWhere( [ 'OR' => [ 'color' => 'green', 'taste' => 'spicy' ] ] )
```

Will return all models which are either green OR spicy.

Note that if because if the use of keyed arrays (which makes it easier to write most queries), ORing on the same field requires a sub-clause for each field invocation, so something like this:

```
Model::findWhere( [ 'OR' => [
  [ 'status' => '3' ],
  [ 'status' => '4' ],
])
```

will issue and SQL `WHERE` statement like this:

```
... WHERE ( (status = 3) OR (status = 4) )
```

this works because when the recursive parser encounters the list of arrays to be `OR`ed, it will create a sub-clause for each (wrap them in parens) and recurse with the "logical operator" being the index of the sub-sub-clause (because sub-sub-clauses are elements in an **indexed** array, their _key_ is their ordinal number). In the next recursion frame, there is only one condition (inside the inner most array) and that resolves fine and we won't use the logical operator at all.

But I also added some code to protect against misuse like this:

```
Model::findWhere( [ 'OR' => [
  [ 'status' => '3' , 'color' => 'green' ],
  [ 'status' => '4' ],
])
```

so if an index is received as the "logical operator", `AND` will be used automatically - like it does by default to the parent clause group.
