### PR TITLE
fixed use of order clause

### DIFF
--- a/src/Database.php
+++ b/src/Database.php
@@ -112,9 +112,9 @@ class Database
     {
         $query = "SELECT $fields FROM $table "
                  .($where ? " WHERE $where " : '')
+                 .($order ? " ORDER BY $order " : '')
                  .($limit ? " LIMIT $limit " : '')
-                 .(($offset && $limit ? " OFFSET $offset " : ''))
-                 .($order ? " ORDER BY $order " : '');
+                 .(($offset && $limit ? " OFFSET $offset " : ''));
         $this->prepare($query);
     }
 


### PR DESCRIPTION
In SQL the ORDER BY clause should come before the LIMIT clause
